### PR TITLE
[fix]  change const into var

### DIFF
--- a/lib/orders/system.js
+++ b/lib/orders/system.js
@@ -68,7 +68,7 @@ var calculateCPU = function () {
 };
 
 var getLoadAvg = function () {
-  const loads = fs.readFileSync('/proc/loadavg', 'utf8').trim().split(' ');
+  var loads = fs.readFileSync('/proc/loadavg', 'utf8').trim().split(' ');
   if (loads) {
     var load1 = Number(loads[0]);
     var load5 = Number(loads[1]);
@@ -117,8 +117,8 @@ var getFreeMemory = function () {
 };
 
 var status = function () {
-  const is_linux = os.type() === 'Linux';
-  const loadavg = is_linux ? getLoadAvg() : os.loadavg();
+  var is_linux = os.type() === 'Linux';
+  var loadavg = is_linux ? getLoadAvg() : os.loadavg();
   return {
     uptime: os.uptime(), // in ms
     totalmem: is_linux ? getTotalMemory() : os.totalmem(), // in byte


### PR DESCRIPTION
In order to run in node 0.12.7, change `const` into `var`.